### PR TITLE
Option to disable jit while using decorator

### DIFF
--- a/pcax/interface/decorators.py
+++ b/pcax/interface/decorators.py
@@ -160,7 +160,10 @@ __jit_debug = {
 }
 
 
-def jit(fn):
+def jit(fn, disable: bool = False):
+    if disable:
+        return fn
+
     def body(_hash, *args, **kwargs):
         if _C["debug"] is True:
             if fn not in __jit_debug["counter"]:


### PR DESCRIPTION
It would be nice, if we could disable jit without changing the structure of the code.
For example, use it like this:

```python
@pxi.jit(disable=True)
def free_test_on_batch(state, model, x, key, trainer, loss_fn, optim):
```
