### PR TITLE
Removed -public from the version to make poetry install work again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pcx"
-version = "0.6.1-public"
+version = "0.6.1"
 packages = [{ include = "pcax" }]
 description = "A library for efficient Predictive Coding networks."
 authors = ["Luca Pinchetti <luca.pinchetti@cs.ox.ac.uk>"]


### PR DESCRIPTION
The -public part in the version confuses poetry.