### PR TITLE
Fix bug where __contains__ and __get__ iterate through None

### DIFF
--- a/pcx/core/_parameter.py
+++ b/pcx/core/_parameter.py
@@ -314,7 +314,7 @@ class ParamDict(DynamicParam):
     def get(
         self, key: str | None = None, default: jax.Array | Any | None = None
     ) -> Any:
-        return self._value.get(key, default) if key is not None else self._value
+        return self._value.get(key, default) if self._value is not None and key is not None else self._value
 
     def set(self, value) -> None:
         self._value = value

--- a/pcx/core/_parameter.py
+++ b/pcx/core/_parameter.py
@@ -309,7 +309,7 @@ class ParamDict(DynamicParam):
         self._value[__key] = __value
 
     def __contains__(self, __key: str) -> bool:
-        return __key in self._value
+        return self._value is not None and __key in self._value
 
     def get(
         self, key: str | None = None, default: jax.Array | Any | None = None


### PR DESCRIPTION
`VodeParam.Cache` inherits from `ParamDict` and calls `super().__init__(params)` where `params` can be `None`. The `ParamDict` constructor calls `super().__init__(value)` which sets `self._value = value`, so if `params` is `None`, then `self._value` becomes `None`. The `__contains__` function is then susceptible to trying to iterate through a `None`, which has been happening to me. A similar thing happens with the `__get__` function.