### PR TITLE
ci: group dependabot action updates into a single monthly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
       interval: monthly
     commit-message:
       prefix: "ci"
+    # One combined PR per monthly run instead of one per action. Six separate
+    # bumps meant six rebases and six full CI matrix runs (see issue #87).
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
## What

Adds a `groups` entry for `github-actions` in `.github/dependabot.yml`, so a monthly run opens one combined PR instead of one per action.

Closes #87

## Why

The first monthly run opened six PRs (#81 to #86). Each merge rebased the rest and re-ran the full 32-job matrix. Grouped, the same batch is one PR, one CI run, one review.

## Notes

No open dependabot PRs remain, so the config lands cleanly before the next run.