### PR TITLE
Stop Optim.step(scale_by) mutating the caller's gradients

### DIFF
--- a/pcx/utils/_optim.py
+++ b/pcx/utils/_optim.py
@@ -92,7 +92,9 @@ class Optim(BaseModule):
 
                     return g
 
-                return set(g, g * scale_by)
+                # 'grads' is often reused (e.g. by a second optimiser), so scale a copy. 'tree_map' rebuilds the
+                # Param through its registered unflatten, preserving the subclass and its attributes (e.g. 'frozen').
+                return jtu.tree_map(lambda _g: _g * scale_by, g)
         else:
 
             def _map_grad(g):

--- a/tests/numerics/test_optim.py
+++ b/tests/numerics/test_optim.py
@@ -131,7 +131,6 @@ def test_adam_step_matches_optax_driven_directly():
 # scale_by #############################################################################
 
 
-@pytest.mark.bug("#67: Optim.step(scale_by=k) writes g*k back into the caller's gradient Params in place")
 def test_step_does_not_mutate_the_caller_gradients():
     """``scale_by`` is documented as scaling the gradients *before* handing them to
     optax — an input to the step, not a side effect on the caller's tree.
@@ -152,7 +151,6 @@ def test_step_does_not_mutate_the_caller_gradients():
     )
 
 
-@pytest.mark.bug("#67: Optim.step(scale_by=k) mutates grads in place, so repeated steps compound k")
 def test_two_scaled_steps_apply_the_same_scaling_each_time():
     """Two SGD steps with the same gradients and the same ``scale_by`` must move the
     weight by ``2 * lr * k * g``.


### PR DESCRIPTION
## Bug

`Optim.step(scale_by=k)` scaled each gradient with `set(g, g * scale_by)`. `set` writes the new value into the `Param` object it is given, and that object is the caller's, not a copy. So the call mutated the gradient tree the caller still holds.

## Impact

Stepping the same gradient tree twice compounds the scaling. With `lr=1.0`, `scale_by=0.5`, `g=1.0`, `w0=1.0`, two steps must give `1 - 2*(1.0*0.5*1.0) = 0.0`; PCX gives `0.25`, because the gradient is 0.5 on the second step and 0.25 on the third.

Every tutorial hits this: they compute one gradient tree and feed it to both `optim_h` and `optim_w` with `scale_by=1.0/batch_size`. The effective learning rate shrinks geometrically with nothing to show for it but slow convergence.

The same mechanism also compounds within a single step on a `pxnn.shared` model, since the outer `tree_map` visits an aliased `Param` once per reference.

## Fix

```python
return jtu.tree_map(lambda _g: _g * scale_by, g)
```

`tree_map` descends into the `Param` (it is a registered pytree), scales the value, and rebuilds a new `Param` via the registered unflatten. The caller's object is untouched.

## Why `tree_map` and not `type(g)(g * scale_by)`

The registered unflatten copies `__dict__` minus `_value`, so the subclass and all its attributes survive. Constructing through `__init__` does not: a rebuilt `VodeParam` would lose `frozen`, the attribute the tutorials set on the output node and that `M_hasnot(VodeParam, frozen=True)` reads. A mask over the scaled tree would then select the wrong parameters.

`OptimTree.step` delegates here, so it inherits the fix.

Closes #67
