### PR TITLE
Make `~` in the mask DSL actually negate

### DIFF
--- a/pcx/utils/_mask.py
+++ b/pcx/utils/_mask.py
@@ -149,7 +149,7 @@ class M:
 class _M_not(M):
     """Computes the logical not of a mask or type"""
 
-    def __call__(self, leaf: Any):
+    def apply(self, leaf: Any):
         return not M._resolve(self.mask, leaf)
 
 

--- a/tests/utils/test_mask.py
+++ b/tests/utils/test_mask.py
@@ -210,7 +210,6 @@ def test_m_is_is_equivalent_to_chaining_and(model):
 # Negation #############################################################################
 
 
-@pytest.mark.bug("#68: `_M_not` overrides `__call__` instead of `apply`, so `~M(A)` never negates the leaf predicate")
 def test_negation_of_a_leaf_predicate_is_the_logical_not(model):
     """``(~M(A)).apply(p)`` must be ``not M(A).apply(p)`` for every parameter.
 
@@ -226,14 +225,13 @@ def test_negation_of_a_leaf_predicate_is_the_logical_not(model):
         assert negative.apply(param) == (not positive.apply(param)), f"~ did not negate at {path}"
 
 
-@pytest.mark.bug("#68: `~M(A)` applied to a model returns a bare bool instead of a masked pytree")
 def test_negation_applied_to_a_model_selects_the_complement(model):
     """``(~M(A))(model)`` must select every parameter ``M(A)`` rejects, and no other.
 
     This is the ordinary user-facing use — "optimise everything except the weights".
-    ``M.__call__`` is the tree-application entry point; ``_M_not`` redefines it as a
-    single-leaf predicate, so the call returns a scalar and the caller receives
-    something that cannot be used as a mask at all.
+    ``M.__call__`` is the tree-application entry point and ``apply`` is the per-leaf
+    predicate, so negation belongs on ``apply``. Installed on ``__call__`` instead it
+    returns a scalar, and the caller gets something unusable as a mask.
     """
     masked = (~pxu.M(pxnn.LayerParam))(model)
 
@@ -241,15 +239,15 @@ def test_negation_applied_to_a_model_selects_the_complement(model):
     assert _kept(masked).keys() == complement
 
 
-@pytest.mark.bug("#68: negation is ignored inside `&`/`|`: `M(A) & ~M(B)` resolves to `M(A) & M(B)`")
 def test_and_with_a_negated_mask_excludes_the_negated_set(model):
     """``M(A) & ~M(B)`` selects the ``A``s that are not ``B``s.
 
     This composed form is the DSL's own documented example
-    (``(M(A | B)) & ~M_has(C, attr1=1)``). Because ``_M_not`` leaves ``apply``
-    inherited, the combinator resolves the *positive* predicate, so the expression
-    silently computes ``M(A) & M(B)`` — here an empty selection where the whole layer
-    was meant to be chosen.
+    (``(M(A | B)) & ~M_has(C, attr1=1)``). The combinators resolve their operands
+    through ``apply``, so a ``_M_not`` that does not override ``apply`` leaves them
+    resolving the *positive* predicate: the expression silently computes
+    ``M(A) & M(B)`` — here an empty selection where the whole layer was meant to be
+    chosen.
     """
     masked = (pxu.M(pcx.Param) & ~pxu.M(pxc.VodeParam))(model)
 
@@ -258,7 +256,6 @@ def test_and_with_a_negated_mask_excludes_the_negated_set(model):
     assert _kept(masked).keys() == expected
 
 
-@pytest.mark.bug("#68: negation never negates, so De Morgan's laws do not hold for the mask algebra")
 def test_de_morgan_holds_for_the_leaf_predicate(model):
     """``~(M(A) | M(B))`` and ``~M(A) & ~M(B)`` must agree, and both must be the complement.
 
@@ -273,6 +270,31 @@ def test_de_morgan_holds_for_the_leaf_predicate(model):
         expected = not (isinstance(param, pxnn.LayerParam) or isinstance(param, pxc.VodeParam))
         assert (~(a | b)).apply(param) == expected, f"~(A | B) wrong at {path}"
         assert (~a & ~b).apply(param) == expected, f"~A & ~B wrong at {path}"
+
+
+@pytest.mark.bug("#88: `M.__call__` reffs the tree first, so a negated mask selects the `_BaseParamRef` placeholders")
+def test_negation_does_not_select_deduplication_placeholders():
+    """A mask must select parameters, never the bookkeeping `tree_ref` leaves behind.
+
+    `M.__call__` calls `tree_ref` first, which replaces every duplicate `BaseParam`
+    reference with a `_BaseParamRef` holding an integer index. A positive mask rejects
+    those because they are not the requested type; a negated mask selects them for the
+    same reason. They then reach `Optim.apply_updates`, whose `get(p)` returns the raw
+    index and adds it to the parameter, so a shared model trains on numbers that are
+    off by the ref index with nothing raised.
+    """
+
+    class Shared(pcx.Module):
+        def __init__(self):
+            super().__init__()
+            self.a = pxnn.Linear(2, 2)
+            self.b = self.a
+
+    selected = _kept((~pxu.M(pxc.VodeParam))(Shared())).values()
+
+    assert not [p for p in selected if type(p).__name__ == "_BaseParamRef"], (
+        "a negated mask selected the de-duplication placeholders inserted by tree_ref"
+    )
 
 
 # Mapping to values ####################################################################


### PR DESCRIPTION
## Bug

`M` has two distinct entry points, and they do different jobs:

- `apply(leaf)` is the per-leaf predicate. Given one `Param`, return True or False.
- `__call__(pydag)` is the tree walker. It reffs the tree, evaluates `apply` at every `Param`, and returns a copy with rejected leaves replaced by `None`.

`~M(A)` constructs a `_M_not`, which needs to invert the predicate. It overrode `__call__` instead of `apply`, so the negation was installed on the walker and never reached the predicate.

## Impact

Two silent failures.

`(~M(A))(model)` stopped walking the tree. It evaluated the predicate once against the whole model and returned a bare `True` rather than a masked pytree.

Worse, `_M_and.apply` and `_M_or.apply` resolve their operands by calling `.apply` on each one. `_M_not` never overrode `apply`, so it inherited `M`'s positive version. `M(A) & ~M(B)` therefore computed `M(A) & M(B)`, selecting exactly the parameters the user asked to exclude, which trains the wrong parameters and freezes the ones meant to learn. That expression appears in `M`'s own class docstring. De Morgan's laws did not hold either.

## Fix

`_M_not` now defines `apply` instead of `__call__`:

```python
class _M_not(M):
    def apply(self, leaf: Any):
        return not M._resolve(self.mask, leaf)
```

That matches `_M_or`, `_M_and` and `_M_hasattr`, which all override `apply` and none of which touch `__call__`. The negation now sits where `M._resolve` looks for it, so the combinators see it, and `_M_not` inherits the working `M.__call__` for tree application.

## Also in this PR

Reviewing this branch surfaced a separate defect. `M.__call__` calls `tree_ref` first, which replaces duplicate `Param` references with `_BaseParamRef` placeholders holding integer indices. A positive mask rejects those because they are not the requested type; a negated mask selects them for the same reason, and `Optim.apply_updates` then adds the raw index to the weight. On a shared model, one step gives `2.8` where `-0.2` is correct.

Filed as #88 and guarded by a `bug`-marked test added here. Not fixed: it predates this change (`M(None)` selects them on main today), but `~` working is what makes the path reachable in practice.

Closes #68
