### PR TITLE
Match Vode statuses and rule keys exactly, not by prefix

### DIFF
--- a/pcx/predictive_coding/_vode.py
+++ b/pcx/predictive_coding/_vode.py
@@ -89,11 +89,11 @@ class Ruleset(BaseModule):
         status = status or ""
 
         for _pattern, _rules in self.rules.items():
-            if re.match(_pattern, status) is None:
+            if re.fullmatch(_pattern, status) is None:
                 continue
 
             for _rule in _rules:
-                if _match := re.match(rule_pattern, _rule):
+                if _match := re.fullmatch(rule_pattern, _rule):
                     yield _match.group(1, 2)
 
     def apply_set_transformation(
@@ -245,7 +245,9 @@ class Vode(EnergyModule):
         Returns:
             Vode: returns itself to allow for chaining.
         """
-        _rule_pattern = f"(.*(?<!\\s))\\s*<-\\s*({key}.*)"
+        # The key group is anchored so 'u' cannot match a rule written for 'u2'; the optional tail is the
+        # ':transformation' suffix. 'Ruleset.filter' full-matches, so no trailing anchor is needed here.
+        _rule_pattern = f"(.*(?<!\\s))\\s*<-\\s*({key}(?::.*)?)"
 
         rules = tuple(self.ruleset.filter(self.status, _rule_pattern))
         for _targets, _tform in rules:

--- a/tests/numerics/test_vode_rules.py
+++ b/tests/numerics/test_vode_rules.py
@@ -102,10 +102,6 @@ def test_every_matching_input_rule_fires_and_the_last_write_to_a_target_wins():
     assert_allclose(reversed_.h.get(), U + 1.0, err_msg="rules did not run in the order they were specified")
 
 
-@pytest.mark.bug(
-    "#69: Vode.set interpolates the key into the regex as '({key}.*)', so set('u', ...) fires rules written for u2, "
-    "u_target or any key that merely starts with 'u' — and then never stores u itself"
-)
 def test_setting_one_key_does_not_fire_a_rule_written_for_a_different_key():
     """A rule names the key it reacts to, and `u2` is not `u`.
 
@@ -182,10 +178,6 @@ def test_status_none_does_not_fire_a_rule_registered_for_a_named_status():
     assert_allclose(vode.get("a"), U, err_msg="the '.*' rule did not fire under STATUS.NONE")
 
 
-@pytest.mark.bug(
-    "#69: Ruleset.filter uses re.match, not re.fullmatch, so a status is matched by prefix: any status starting with "
-    "'init' fires the forward-initialisation rule"
-)
 @pytest.mark.parametrize("status", ["initialise", "initialisation", "init_weights", "initial"], ids=lambda s: s)
 def test_a_status_is_matched_exactly_and_not_by_prefix(status: str):
     """A status must match a rule's pattern as a whole, not merely start with it.


### PR DESCRIPTION
## Bug

Two regexes in `_vode.py` were anchored only at their start, so both matched by prefix where they meant to match the whole string.

`Ruleset.filter` used `re.match(pattern, status)`. The built-in ruleset registers its forward-init rules under the pattern `"init"`, so `re.match` accepted any status *beginning* with `init`.

`Vode.set` built its rule pattern as `f"...<-\s*({key}.*)"`. The trailing `.*` means the key group matched any rule whose right-hand side merely starts with the key.

## Impact

A user who names a phase `initialise` or `init_weights` silently gets the `h, u <- u` rule, which copies the prediction into the node value. The prediction error, and therefore the energy, is identically zero for that whole phase.

For keys the damage is doubled. A node with two incoming activations, `u` from the layer above and `u2` from a skip connection, has `u2`'s rule fire with `u`'s value. And because *a* rule matched, the `len(rules) == 0` fallback never runs, so `u` is never stored under its own name at all. With ruleset `("z <- u2",)`, `set("u", 7.0)` left `cache["z"] == 7.0` and `cache["u"]` unset.

## Fix

Both matches become `re.fullmatch`, and the key group gains an explicit optional tail for the `:transformation` suffix:

```python
if re.fullmatch(_pattern, status) is None:      # was re.match
...
if _match := re.fullmatch(rule_pattern, _rule):  # was re.match
...
_rule_pattern = f"(.*(?<!\\s))\\s*<-\\s*({key}(?::.*)?)"   # was ({key}.*)
```

`fullmatch` restores the documented meaning of the patterns as regexes: `.*` is the way to say "any status", which was meaningless while every pattern carried an implicit one. `(?::.*)?` is non-capturing, so `_match.group(1, 2)` still yields the same targets and transformation.

## Why not a trailing `$`

`$` also matches immediately before a trailing newline, so it is strictly weaker than `fullmatch`. It would also leave `Ruleset.filter` applying whole-string matching to its status argument and prefix matching to its rule argument, with the anchoring obligation pushed into an undocumented caller convention that `Vode.get` does not follow.

Closes #69
