### PR TITLE
Complete Param's operator and sequence protocols

### DIFF
--- a/pcx/core/_parameter.py
+++ b/pcx/core/_parameter.py
@@ -185,27 +185,25 @@ class Param(DynamicParam):
         self._value = self._value.__mul__(get(__other))
         return self
 
-    def __div__(self, __other):
-        return self._value.__div__(get(__other))
-
-    def __rdiv__(self, __other):
-        return self._value.__rdiv__(get(__other))
-
-    def __idiv__(self, __other):
-        self._value = self._value.__div__(get(__other))
-        return self
-
     def __truediv__(self, __other):
         return self._value.__truediv__(get(__other))
 
     def __rtruediv__(self, __other):
         return self._value.__rtruediv__(get(__other))
 
+    def __itruediv__(self, __other):
+        self._value = self._value.__truediv__(get(__other))
+        return self
+
     def __floordiv__(self, __other):
         return self._value.__floordiv__(get(__other))
 
     def __rfloordiv__(self, __other):
         return self._value.__rfloordiv__(get(__other))
+
+    def __ifloordiv__(self, __other):
+        self._value = self._value.__floordiv__(get(__other))
+        return self
 
     def __divmod__(self, __other):
         return self._value.__divmod__(get(__other))
@@ -219,11 +217,19 @@ class Param(DynamicParam):
     def __rmod__(self, __other):
         return self._value.__rmod__(get(__other))
 
+    def __imod__(self, __other):
+        self._value = self._value.__mod__(get(__other))
+        return self
+
     def __pow__(self, __other):
         return self._value.__pow__(get(__other))
 
     def __rpow__(self, __other):
         return self._value.__rpow__(get(__other))
+
+    def __ipow__(self, __other):
+        self._value = self._value.__pow__(get(__other))
+        return self
 
     def __matmul__(self, __other):
         return self._value.__matmul__(get(__other))
@@ -231,11 +237,19 @@ class Param(DynamicParam):
     def __rmatmul__(self, __other):
         return self._value.__rmatmul__(get(__other))
 
+    def __imatmul__(self, __other):
+        self._value = self._value.__matmul__(get(__other))
+        return self
+
     def __and__(self, __other):
         return self._value.__and__(get(__other))
 
     def __rand__(self, __other):
         return self._value.__rand__(get(__other))
+
+    def __iand__(self, __other):
+        self._value = self._value.__and__(get(__other))
+        return self
 
     def __or__(self, __other):
         return self._value.__or__(get(__other))
@@ -243,11 +257,19 @@ class Param(DynamicParam):
     def __ror__(self, __other):
         return self._value.__ror__(get(__other))
 
+    def __ior__(self, __other):
+        self._value = self._value.__or__(get(__other))
+        return self
+
     def __xor__(self, __other):
         return self._value.__xor__(get(__other))
 
     def __rxor__(self, __other):
         return self._value.__rxor__(get(__other))
+
+    def __ixor__(self, __other):
+        self._value = self._value.__xor__(get(__other))
+        return self
 
     def __lshift__(self, __other):
         return self._value.__lshift__(get(__other))
@@ -255,14 +277,34 @@ class Param(DynamicParam):
     def __rlshift__(self, __other):
         return self._value.__rlshift__(get(__other))
 
+    def __ilshift__(self, __other):
+        self._value = self._value.__lshift__(get(__other))
+        return self
+
     def __rshift__(self, __other):
         return self._value.__rshift__(get(__other))
 
     def __rrshift__(self, __other):
         return self._value.__rrshift__(get(__other))
 
+    def __irshift__(self, __other):
+        self._value = self._value.__rshift__(get(__other))
+        return self
+
     def __round__(self, ndigits=None):
         return self._value.__round__(ndigits)
+
+    def __float__(self):
+        return self._value.__float__()
+
+    def __int__(self):
+        return self._value.__int__()
+
+    def __len__(self):
+        return self._value.__len__()
+
+    def __iter__(self):
+        return self._value.__iter__()
 
     def __getitem__(self, __idx):
         return self._value.__getitem__(__idx)

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -103,11 +103,7 @@ def test_tree_map_over_a_subclass_returns_that_subclass():
         (operator.iadd, 6.0),
         (operator.isub, 2.0),
         (operator.imul, 8.0),
-        pytest.param(
-            operator.itruediv,
-            2.0,
-            marks=pytest.mark.bug("#70: Param defines __idiv__ (Python 2) but no __itruediv__, so `p /= x` rebinds"),
-        ),
+        (operator.itruediv, 2.0),
     ],
     ids=["iadd", "isub", "imul", "itruediv"],
 )

--- a/tests/core/test_parameter_ops.py
+++ b/tests/core/test_parameter_ops.py
@@ -225,10 +225,6 @@ def test_indexing_matches_the_bare_array(index):
     assert_same_array(pcx.Param(A)[index], A[index], context=f"Param[{index!r}]")
 
 
-@pytest.mark.bug(
-    "#70: iterating a Param never terminates: no __iter__, and the __getitem__ fallback never stops because "
-    "jax clamps an out-of-bounds index instead of raising IndexError"
-)
 def test_iterating_a_param_yields_exactly_the_elements_of_the_array():
     """`for row in w` must walk the leading axis exactly as `for row in w.get()` does,
     and must stop at the end of it.
@@ -251,7 +247,6 @@ def test_iterating_a_param_yields_exactly_the_elements_of_the_array():
         assert_same_array(actual, expected, context=f"row {i}")
 
 
-@pytest.mark.bug("#70: Param forwards __getitem__ and .shape but defines no __len__, so len(param) raises TypeError")
 def test_len_matches_the_bare_array():
     """`len(w)` must be the size of the leading axis, as it is for the array.
 
@@ -266,7 +261,6 @@ def test_len_matches_the_bare_array():
     assert len(pcx.Param(A)) == len(A)
 
 
-@pytest.mark.bug("#70: Param forwards no __float__/__int__, so float(param) on a scalar parameter raises TypeError")
 def test_scalar_conversions_match_the_bare_array():
     """`float(loss)` and `int(count)` on a zero-dimensional parameter must give the
     same Python number the wrapped array gives.
@@ -372,10 +366,6 @@ def test_repr_of_an_empty_param_does_not_raise():
 # assignments are below.
 
 
-@pytest.mark.bug(
-    "#70: Param defines only __iadd__/__isub__/__imul__, so //= %= **= @= &= |= ^= <<= >>= "
-    "all rebind the name to a bare jax.Array and the parameter silently keeps its old value"
-)
 @pytest.mark.parametrize(
     ("op", "start", "other", "expected"),
     [


### PR DESCRIPTION
## Bug

`Param` forwards `.shape` and `__getitem__` to the array it wraps, so it presents as a sequence and a number. The dunders that make those protocols work were missing.

Python's augmented assignment falls back to the binary operator when the in-place form is absent, and then **rebinds the name**. `Param` defined only `__iadd__`, `__isub__` and `__imul__`, plus a Python 2 `__idiv__` that calls a non-existent `Array.__div__`.

Iteration has a similar fallback: with no `__iter__`, Python uses the legacy `__getitem__` protocol, which terminates only on `IndexError`.

## Impact

```python
p = model.layer.weight
p /= 2.0            # p is now a bare jax.Array; model.layer.weight is unchanged
```

The update is silently discarded. `+=` works correctly, which is exactly what stops anyone noticing. Affects `/=`, `//=`, `%=`, `**=`, `@=`, `&=`, `|=`, `^=`, `<<=`, `>>=`.

`list(param)` never terminates: jax clamps an out-of-bounds index instead of raising, so the fallback protocol keeps yielding the last element forever. It hangs rather than fails.

`float(loss)` on a scalar parameter, in every logging line ever written, raises `TypeError`.

## Fix

Add the ten missing in-place operators plus `__iter__`, `__len__`, `__float__` and `__int__`, each a single delegation in the file's existing idiom:

```python
def __itruediv__(self, __other):
    self._value = self._value.__truediv__(get(__other))
    return self
```

Assigning to `self._value` and returning `self` is what preserves object identity, which is the invariant the library's update tracking rests on. `__iter__` is what actually stops the hang: defining it pre-empts the `__getitem__` fallback entirely.

Removes `__div__`, `__rdiv__` and `__idiv__`; `jax.Array` has none of them, so all three could only ever raise.

## Why the `ty` count rises

237 to 245, on the advisory job. All 14 new diagnostics are the same `unresolved-attribute` message that the ~31 existing forwards in this file already emit, caused by `_value` being typed `jax.Array | Any | None`; 6 pre-existing ones are resolved. Suppressing would need `# type: ignore`, which appears nowhere in `pcx/`, and narrowing `_value`'s type is a far larger change than this issue authorises.

Closes #70
