### PR TITLE
Restore the global RKG key when a transform raises

### DIFF
--- a/pcx/functional/_transform.py
+++ b/pcx/functional/_transform.py
@@ -125,11 +125,13 @@ class _BaseTransform(abc.ABC):
                 def _wrap_fn(*args, **kwargs):
                     # Update the global RKG key with the transformed one so it is accessible globally.
                     _old_key, RKG.key = RKG.key, kwargs["__RKG"].key
-                    _r = fn(*args, **kwargs, _is_root=False)
-
-                    # Replace the new key with the old ones to avoid leaks. It will be overwritten anyway immediately
-                    # outside of the transformation bounds.
-                    RKG.key = _old_key
+                    try:
+                        _r = fn(*args, **kwargs, _is_root=False)
+                    finally:
+                        # Replace the new key with the old ones to avoid leaks. It will be overwritten anyway
+                        # immediately outside of the transformation bounds. This must happen even if 'fn' raises,
+                        # or the traced key stays in the global RKG and poisons every later random draw.
+                        RKG.key = _old_key
 
                     return _r, kwargs
 
@@ -143,11 +145,12 @@ class _BaseTransform(abc.ABC):
                 # called.
                 def _wrap_fn(*args, **kwargs):
                     _old_key, RKG.key = RKG.key, kwargs["__RKG"].key
-                    _fn_kwargs = tree_unref(kwargs)
-                    del _fn_kwargs["__RKG"]
-                    _r = fn(*args, **_fn_kwargs)
-
-                    RKG.key = _old_key
+                    try:
+                        _fn_kwargs = tree_unref(kwargs)
+                        del _fn_kwargs["__RKG"]
+                        _r = fn(*args, **_fn_kwargs)
+                    finally:
+                        RKG.key = _old_key
 
                     return _r, kwargs
 

--- a/tests/functional/test_flow.py
+++ b/tests/functional/test_flow.py
@@ -709,7 +709,6 @@ def test_cond_advances_the_global_rkg_exactly_like_a_raw_jax_split():
     assert jnp.array_equal(pcx.RKG.key.get(), fresh[0]), "the global key must be advanced past the consumed one"
 
 
-@pytest.mark.bug("#71: the global RKG key is left holding a jax tracer when a flow function raises (no try/finally)")
 def test_global_rkg_holds_a_concrete_array_after_a_flow_function_raises():
     """`_BaseTransform` swaps `RKG.key` for the traced key on the way in and
     restores it on the way out, but the restore is a plain statement rather than a

--- a/tests/functional/test_transforms.py
+++ b/tests/functional/test_transforms.py
@@ -606,9 +606,6 @@ def test_repeated_jitted_draws_follow_the_raw_jax_key_stream():
         assert jnp.array_equal(pcx.RKG.key.get(), key), f"global key diverged at call {call}"
 
 
-@pytest.mark.bug(
-    "#71: the global RKG key is left holding a jax tracer when a transformed function raises (no try/finally)"
-)
 def test_global_rkg_holds_a_concrete_array_after_a_transformed_function_raises():
     """`_BaseTransform` swaps `RKG.key` for the traced key on the way in and
     restores it on the way out — but the restore is a plain statement, not a


### PR DESCRIPTION
## Bug

Inside a transform, `_wrap_fn` swaps the global `RKG.key` for the traced key so that layers constructed within the transform draw from the traced stream, then swaps it back:

```python
_old_key, RKG.key = RKG.key, kwargs["__RKG"].key
_r = fn(*args, **kwargs, _is_root=False)
RKG.key = _old_key          # plain statement, not a finally
```

If `fn` raises, the restore never runs and the tracer stays in module-level state.

## Impact

`pcx.RKG` is the default argument of every layer and Vode constructor, so a leaked tracer breaks every subsequent random draw in the process with `UnexpectedTracerError`, including in code that never touched a transform. One failed `pxf.jit` call is enough. Under pytest, one failing test breaks every later test that constructs a layer.

## Fix

`try/finally` around the call, at both swap sites:

```python
try:
    _r = fn(*args, **kwargs, _is_root=False)
finally:
    RKG.key = _old_key
```

The success path is unchanged; `return _r, kwargs` stays outside the `try`. The flow transforms (`scan`, `while_loop`, `cond`, `switch`) inherit `_BaseTransform` and route through the same closures, so both guarding tests are covered by these two edits.

Nesting restores correctly in LIFO order: for `jit(value_and_grad(f))` the inner `finally` restores the outer transform's tracer, and the outer `finally` restores the concrete key.

## Follow-up, not fixed here

`Vmap._t` has the same shape of bug at a different site: it splits the global key over the batch axis and merges it back with the merge outside any `try`, so a raising `pxf.vmap` leaves the key with an extra leading axis. Concrete rather than traced, so this PR's guarding test (which asserts "not a tracer") passes while the process is still poisoned. Different function, different fix, filed as #91.

Closes #71
