### PR TITLE
Fix shared-parameter checkpoints and check shapes on load

### DIFF
--- a/pcx/utils/_serialisation.py
+++ b/pcx/utils/_serialisation.py
@@ -9,7 +9,7 @@ import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import PyTree
 
-from ..core._parameter import BaseParam
+from ..core._parameter import BaseParam, get
 from ..core._tree import _cache
 from ..nn._parameter import LayerParam
 
@@ -42,7 +42,7 @@ def save_params(
 
     _params = jtu.tree_flatten_with_path(model, is_leaf=_filter_fn)[0]
 
-    # Cache to check for duplicate parameters.
+    # Cache to check for duplicate parameters: a shared parameter is saved only under its first path.
     _seen = _cache()
     _data = {}
     for key, param in _params:
@@ -50,8 +50,6 @@ def save_params(
             assert isinstance(param, BaseParam), "Only parameters can be serialized."
             if _seen(id(param)) is None:
                 _data[jtu.keystr(key)] = param.get()
-            else:
-                _data[jtu.keystr(key)] = None
 
     np.savez_compressed(path, **_data)
 
@@ -79,6 +77,7 @@ def load_params(
 
     Raises:
         KeyError: the file does not contain all the parameters required by the model.
+        ValueError: a stored parameter does not have the shape of its target parameter.
     """
     path = path if path.endswith(".npz") else f"{path}.npz"
     _filter_fn = filter if not isinstance(filter, type | UnionType) else lambda x: isinstance(x, filter)
@@ -86,12 +85,21 @@ def load_params(
     _loaded_values = np.load(path)
     _params = jtu.tree_flatten_with_path(model, is_leaf=_filter_fn)[0]
 
+    # Mirrors 'save_params': a shared parameter is stored only under its first path.
+    _seen = _cache()
     for _key, _param in _params:
-        if _filter_fn(_param):
+        if _filter_fn(_param) and _seen(id(_param)) is None:
             _key = jtu.keystr(_key)
             if _key not in _loaded_values:
                 raise KeyError(f"Parameter '{_key}' not found in the file '{path}'.")
-            elif (_value := _loaded_values[_key]) is not None:
-                _param.set(jax.numpy.array(_value))
+            _value = _loaded_values[_key]
+            # A target parameter that holds nothing yet (a freshly built Vode, for example) has no shape to
+            # compare against, so it accepts whatever the file stores.
+            _current = get(_param)
+            if _current is not None and jax.numpy.shape(_current) != _value.shape:
+                raise ValueError(
+                    f"Parameter '{_key}' has shape {jax.numpy.shape(_current)} but the file stores {_value.shape}."
+                )
+            _param.set(jax.numpy.array(_value))
 
     _loaded_values.close()

--- a/tests/utils/test_serialisation.py
+++ b/tests/utils/test_serialisation.py
@@ -121,6 +121,30 @@ def test_a_non_default_filter_saves_the_selected_parameters(rkg, ckpt):
     np.testing.assert_array_equal(np.asarray(pcx.get(target.vode.h)), np.array([3.0, -4.0]))
 
 
+def test_loading_into_a_freshly_constructed_model_works(rkg, ckpt):
+    """The documented workflow is `model = Model(); load_params(model, ...)`, so the
+    target's parameters still hold `None` when the load runs.
+
+    A `Vode` is built with an empty `h`, which is exactly that state, so anything the
+    loader reads off the target parameter has to tolerate it. The sibling tests all
+    seed the target first, which is how this path stayed uncovered.
+    """
+
+    class WithVode(pcx.Module):
+        def __init__(self):
+            self.layer = pxnn.Linear(2, 2, rkg=rkg)
+            self.vode = pxc.Vode()
+
+    source, target = WithVode(), WithVode()
+    source.vode.h.set(jnp.array([3.0, -4.0]))
+    assert pcx.get(target.vode.h) is None, "the target must start empty for this test to mean anything"
+
+    pxu.save_params(source, ckpt, filter=pxc.VodeParam)
+    pxu.load_params(target, ckpt, filter=pxc.VodeParam)
+
+    np.testing.assert_array_equal(np.asarray(pcx.get(target.vode.h)), np.array([3.0, -4.0]))
+
+
 def test_missing_parameter_raises_key_error(net, other_net, ckpt):
     """A checkpoint that does not cover the model must fail loudly. Silently
     leaving a layer at its random initialisation is the worst outcome."""
@@ -141,7 +165,6 @@ def test_keys_are_stable_attribute_paths(net, ckpt):
         assert set(f.files) == {".a.nn.weight", ".a.nn.bias", ".b.nn.weight", ".b.nn.bias"}
 
 
-@pytest.mark.bug("#73: load_params does no shape check, so a mismatched checkpoint overwrites silently")
 def test_shape_mismatch_is_rejected(rkg, ckpt):
     """Loading a checkpoint from a differently-shaped model must not succeed.
     It currently overwrites the parameter with the wrong shape, which surfaces
@@ -160,7 +183,6 @@ def test_shape_mismatch_is_rejected(rkg, ckpt):
     assert loaded.shape == original.shape, f"silently loaded a {loaded.shape} weight into a {original.shape} parameter"
 
 
-@pytest.mark.bug("#73: duplicate refs are written as None, so np.load refuses the object array")
 def test_round_trip_preserves_shared_parameters(rkg, ckpt):
     """A model using `pxnn.shared` must checkpoint and restore like any other.
 


### PR DESCRIPTION
## Bug

Two defects in `_serialisation.py`.

`save_params` deduplicates shared parameters by writing the value under the first path it meets and a literal `None` under every later one. `np.savez_compressed` stores that `None` as a 0-d `dtype=object` array. `load_params` then calls `np.load`, which refuses object arrays unless `allow_pickle=True`.

Separately, `load_params` assigned whatever the file held without comparing shapes.

## Impact

Every checkpoint of a model using `pxnn.shared` is unrecoverable:

```
ValueError: Object arrays cannot be loaded when allow_pickle=False
```

The loader's `is not None` guard was dead code, since `np.load` yields a 0-d object array and never `None`, so even with `allow_pickle=True` the shared parameter would have been assigned garbage.

Without a shape check, a `Linear(5, 7)` checkpoint loaded into a `Linear(2, 3)` leaves the weight at `(7, 5)`, surfacing much later as an inscrutable broadcasting error inside a training step.

## Fix

The sentinel the writer and reader had to agree on turned out to be *no key at all*. `save_params` drops the `else` branch, so duplicates are simply not written; `load_params` mirrors it with the same `_cache()` idiom, skipping the same paths. No object array is ever created, so nothing needs `allow_pickle`.

Plus a shape comparison raising `ValueError` before assignment.

## Compatibility

Old checkpoints still load, including shared ones that previously could not. `np.load` on an `.npz` is lazy and the loader no longer visits the duplicate paths, so the stale `dtype=object` entries are never read.

The shape check runs only when the target parameter already holds a value. A freshly constructed `Vode` has `h` set to `None`, and `model = Model(); load_params(model, ...)` is the documented workflow, so an unconditional `_param.shape` raised `AttributeError` on the normal path. Found in review; regression test added, since every sibling test seeded its target first and left that path uncovered.

Closes #73
