### PR TITLE
Return zero energy for a module with no Vodes

### DIFF
--- a/pcx/predictive_coding/_energy_module.py
+++ b/pcx/predictive_coding/_energy_module.py
@@ -42,7 +42,9 @@ class EnergyModule(Module):
         Returns:
             jax.Array: total energy of the module.
         """
-        return functools.reduce(lambda x, y: x + y, (m.energy() for m in self.submodules(cls=EnergyModule)))
+        return functools.reduce(
+            lambda x, y: x + y, (m.energy() for m in self.submodules(cls=EnergyModule)), jax.numpy.asarray(0.0)
+        )
 
     def clear_params(self, filter: Callable[[Any], bool] | type) -> None:
         """Set the selected parameters to None. This is especially useful to clear the cache of the

--- a/tests/numerics/test_vode.py
+++ b/tests/numerics/test_vode.py
@@ -44,7 +44,6 @@ class _NoVodes(pxc.EnergyModule):
 # Energy accumulation ##################################################################
 
 
-@pytest.mark.bug("#72: EnergyModule.energy() reduces over an empty iterable and raises TypeError")
 def test_energy_of_a_module_with_no_vodes_is_zero():
     """The total energy of a module is the sum over its Vodes, and the sum over an
     empty collection is zero.


### PR DESCRIPTION
## Bug

```python
return functools.reduce(lambda x, y: x + y, (m.energy() for m in self.submodules(cls=EnergyModule)))
```

`functools.reduce` with no initial value raises on an empty iterable rather than returning an identity.

## Impact

A module with no `EnergyModule` children raises `TypeError: reduce() of empty iterable with no initial value` instead of returning zero. That hits any model built up incrementally, and any leaf module in a hierarchy that happens to hold no Vode.

## Fix

Seed the reduction with `jax.numpy.asarray(0.0)`.

## Why that value

Four candidates, measured:

- `0` breaks `jax.grad` on the empty case: *grad requires real-valued outputs, got int32*.
- `0.0` works numerically but returns a Python `float` for the empty case, contradicting the method's documented `jax.Array` return, and costs one extra `ty` diagnostic.
- `jnp.zeros(())` is strongly typed float32, so it silently upcasts a bfloat16 or float16 energy in the *non-empty* case.
- `jax.numpy.asarray(0.0)` is a `jax.Array` that keeps `weak_type=True`, so it adopts the operand's dtype and leaves the non-empty result untouched.

Confirmed bit-identical to main on the non-empty path, both unbatched and under `pxf.vmap`.

Closes #72
