### PR TITLE
Sort module attributes when flattening

### DIFF
--- a/pcx/core/_module.py
+++ b/pcx/core/_module.py
@@ -65,15 +65,20 @@ class _BaseModuleMeta(abc.ABCMeta):
 
     @staticmethod
     def flatten_module(module: "BaseModule") -> tuple[tuple[Any, ...], tuple[str, ...]]:
-        return tuple(module.__dict__.values()), tuple(module.__dict__.keys())
+        # Keys are sorted, as jax does for dictionaries, so that the structure does not depend on assignment order.
+        _keys = tuple(sorted(module.__dict__))
+
+        return tuple(module.__dict__[k] for k in _keys), _keys
 
     @staticmethod
     def flatten_module_with_keys(
         module: "BaseModule",
     ) -> tuple[tuple[tuple[str, Any], ...], tuple[str, ...]]:
+        _keys = tuple(sorted(module.__dict__))
+
         return (
-            tuple((jtu.GetAttrKey(k), v) for k, v in module.__dict__.items()),
-            tuple(module.__dict__.keys()),
+            tuple((jtu.GetAttrKey(k), module.__dict__[k]) for k in _keys),
+            _keys,
         )
 
     @staticmethod

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -134,7 +134,6 @@ def test_tree_map_across_two_instances_works():
     assert_allclose(summed.w.get(), jnp.full((3,), 2.0))
 
 
-@pytest.mark.bug("#76: Module treedefs use __dict__ insertion order, so assignment order changes the structure")
 def test_attribute_assignment_order_does_not_change_the_treedef():
     """A module is documented to be "flattened as if it were a dictionary", and a
     dictionary in jax is order-insensitive — `tree_structure({"a": 1, "b": 2})`

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -185,7 +185,12 @@ def test_ref_does_not_disturb_the_values():
 
 def test_extract_yields_one_entry_per_dynamic_param_in_traversal_order():
     """`extract`/`inject` are a positional protocol — the two must agree on the
-    sequence, so extraction has to be deterministic and skip statics."""
+    sequence, so extraction has to be deterministic and skip statics.
+
+    A module flattens by sorted attribute name, deliberately, so that its structure
+    does not depend on the order a constructor happened to assign in. `Leafy` assigns
+    `w` then `b`, so `b` is extracted first.
+    """
     m = Leafy()
     m.w.set(jnp.array([1.0, 2.0]))
     m.b.set(jnp.array([3.0, 4.0]))
@@ -193,8 +198,8 @@ def test_extract_yields_one_entry_per_dynamic_param_in_traversal_order():
     extracted = tree_extract(m, is_pytree=True)
 
     assert len(extracted) == 2
-    assert_allclose(extracted[0].get(), jnp.array([1.0, 2.0]))
-    assert_allclose(extracted[1].get(), jnp.array([3.0, 4.0]))
+    assert_allclose(extracted[0].get(), jnp.array([3.0, 4.0]))
+    assert_allclose(extracted[1].get(), jnp.array([1.0, 2.0]))
 
 
 def test_extract_then_inject_transfers_values_in_order():


### PR DESCRIPTION
## Bug

```python
return tuple(module.__dict__.values()), tuple(module.__dict__.keys())
```

`BaseModule` flattened on `__dict__` insertion order, which is the order a constructor happened to assign attributes in.

## Impact

Two instances of the same class built by different code paths get different treedefs:

```python
class M(pxc.Module):
    def __init__(self, swap):
        if swap: self.b, self.a = Param(1.0), Param(2.0)
        else:    self.a, self.b = Param(2.0), Param(1.0)

jtu.tree_structure(M(False)) == jtu.tree_structure(M(True))   # False
```

They cannot be `tree_map`ed together, and passing one then the other to a jitted function forces a recompile. A module is documented as flattening "as if it were a dictionary", and jax's own dict flattening is deliberately key-order-insensitive for exactly this reason.

## Fix

Sort the keys in both flatten variants. `unflatten_module` rebuilds `__dict__` by zipping aux keys with children, so it consumes whatever order flatten emits and stays consistent automatically.

## Why a test changed

`test_extract_yields_one_entry_per_dynamic_param_in_traversal_order` asserted that `extracted[0]` was `w`, the first-assigned attribute. Its docstring states the contract as "extraction has to be deterministic and skip statics"; *which* deterministic order is precisely what this PR changes, so the positional literals recorded incidental behaviour rather than the contract. No order normalisation of any kind could preserve them. The two expected values are swapped and the docstring now says why.

## Verified

A full two-moons run is bit-identical to main across per-batch energies, test accuracy and every weight elementwise. `tree_ref`/`tree_unref` still restores object identity for an aliased param, and a jitted function called with a `wb`-ordered and a `bw`-ordered instance now traces once instead of twice. Old checkpoints still load, since keys are `jtu.keystr` attribute paths rather than positions.

Reordering a float32 `reduce` can move the last bits of a sum. It does not on the tutorial, whose module attributes are already alphabetical and whose Vodes live in a list, but a constructed worst case shifts the total energy by 5e-6 relative. Inherent to any order normalisation.

Closes #76
