### PR TITLE
Accept the argnums and switch spellings the signatures promise

### DIFF
--- a/pcx/functional/_flow.py
+++ b/pcx/functional/_flow.py
@@ -165,7 +165,7 @@ class Switch(_BaseTransform):
         Args:
             fns (Sequence[_BaseTransformation | Callable]): functions to be called based on index.
         """
-        super().__init__(fns)
+        super().__init__(tuple(fns))
 
         self.t_kwargs = t_kwargs
 

--- a/pcx/functional/_transform.py
+++ b/pcx/functional/_transform.py
@@ -299,6 +299,8 @@ class ValueAndGrad(_BaseTransform):
         self.kwargs_mask = kwargs_mask
         self.has_aux = t_kwargs["has_aux"]
 
+        _argnums = t_kwargs.get("argnums", ())
+        t_kwargs["argnums"] = (_argnums,) if isinstance(_argnums, int) else tuple(_argnums)
         t_kwargs["has_aux"] = True
         self.t_kwargs = t_kwargs
 

--- a/tests/functional/test_flow.py
+++ b/tests/functional/test_flow.py
@@ -544,20 +544,17 @@ def test_switch_matches_jax_lax_switch_for_every_index(index):
     assert_allclose(result, expected)
 
 
-@pytest.mark.bug(
-    "#74: pxf.switch([...]) raises TypeError: _make_tuple leaves a list alone, collapsing all branches into one"
-)
 def test_switch_accepts_a_list_of_branches():
     """`pcx.functional.switch` is typed `branches: Sequence[...]` and mirrors
     `jax.lax.switch`, whose branches are conventionally written as a list — that
     is also how every `jax.lax.switch` example in the wild spells it.
 
     `_BaseTransform.__init__` normalises `fn` with `_make_tuple`, which is
-    `x if isinstance(x, tuple) else (x,)`: a list is not a tuple, so it is wrapped
-    rather than expanded and the whole list becomes a single "function".
-    `Switch._t` then calls `len(self.fn)` on that one wrapped callable and raises
-    `TypeError: object of type 'function' has no len()`. Only the undocumented
-    tuple spelling works.
+    `x if isinstance(x, tuple) else (x,)`: a list is not a tuple, so it used to be
+    wrapped rather than expanded and the whole list became a single "function".
+    `Switch._t` then called `len(self.fn)` on that one wrapped callable and raised
+    `TypeError: object of type 'function' has no len()`, so only the undocumented
+    tuple spelling worked.
     """
     x = jnp.array([2.0, -3.0])
 

--- a/tests/functional/test_transform_internals.py
+++ b/tests/functional/test_transform_internals.py
@@ -226,9 +226,6 @@ def test_value_and_grad_with_a_tuple_argnums_returns_positional_and_keyword_grad
     The result is repacked as `(positional_gradients, kwarg_gradients)`. Both halves
     have to be right: a mis-sliced repack would hand the optimiser the gradient with
     respect to the *input data* as if it were the gradient of the weights.
-
-    (The documented `argnums=0` integer spelling is rejected outright — #74 —
-    so this uses the `(0,)` tuple form that does work.)
     """
     w = jnp.array([0.5, -1.25])
     x = jnp.array([2.0, 3.0])

--- a/tests/functional/test_transforms.py
+++ b/tests/functional/test_transforms.py
@@ -398,17 +398,14 @@ def test_value_and_grad_updates_a_shared_param_exactly_once():
     assert_allclose(state.get(), jnp.array([1.0]))
 
 
-@pytest.mark.bug(
-    "#74: pxf.value_and_grad(argnums=0) raises TypeError: an int argnums is splatted with * instead of wrapped"
-)
 def test_value_and_grad_accepts_an_integer_argnums():
     """`pcx.functional.value_and_grad` advertises `argnums: int | Sequence[int]`,
     matching `jax.value_and_grad`, and a bare `int` is by far the common way to
     ask for the gradient of a single positional argument.
 
     `ValueAndGrad._t` builds `(*self.t_kwargs.get("argnums", ()), len(args))`,
-    which requires `argnums` to be iterable, so the documented `int` form is
-    rejected outright. Only the undocumented `(0,)` spelling works.
+    which requires `argnums` to be iterable, so the documented `int` form used to
+    be rejected outright and only the undocumented `(0,)` spelling worked.
     """
     w = jnp.array([0.5, -1.25])
     x = jnp.array([2.0, 3.0])


### PR DESCRIPTION
## Bug

Two places where the annotation is wider than what the code accepts.

`ValueAndGrad` is typed `argnums: int | Sequence[int]`, matching jax, but `_t` splats it: `jax.value_and_grad(..., argnums=(*argnums, n))`. An `int` is not iterable.

`Switch` is typed `Sequence[...]` and passes `fns` to `_BaseTransform.__init__`, which calls `_make_tuple(fn)`. That helper is `x if isinstance(x, tuple) else (x,)`, so a list of branches is *wrapped* rather than expanded, collapsing all branches into one element.

## Impact

Both documented spellings raise:

```
pxf.value_and_grad(argnums=0)     TypeError: Value after * must be an iterable, not int
pxf.switch([b0, b1, b2])          TypeError: object of type 'function' has no len()
```

Only the undocumented `argnums=(0,)` and a tuple of branches worked.

## Fix

Normalise at each call site: `ValueAndGrad.__init__` wraps an `int` and tuples anything else, and `Switch.__init__` calls `super().__init__(tuple(fns))`.

Normalising in `__init__` rather than `_t` also fixes a silent bug: a generator `argnums` worked on the first call and then returned *no positional gradient at all* on the second, because `_t` re-splatted the now-exhausted generator.

## Why not in `_make_tuple`

Teaching the shared helper to expand sequences breaks four of its six callers. The decisive one is `_process_mask`, which passes mask dict **keys**: `str` is a `Sequence`, so `"model"` would expand into five single-character keys and the mask would fail with a pytree structure error. Two others pass user function return values, where a returned list would be resplit into value plus aux.

Closes #74
