### PR TITLE
Warn instead of printing on ambiguous output rules

### DIFF
--- a/pcx/predictive_coding/_vode.py
+++ b/pcx/predictive_coding/_vode.py
@@ -5,6 +5,7 @@ __all__ = [
 ]
 
 import re
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -290,9 +291,12 @@ class Vode(EnergyModule):
             else:
                 return self.cache.get(key, default)
         else:
-            # TODO: use warnings
             if len(_rules) > 1:
-                print(f"WARNING: Multiple output rules matched for key '{key}' in status '{self.status}'.")
+                warnings.warn(
+                    f"Multiple output rules matched for key '{key}' in status '{self.status}', "
+                    "only the first is applied.",
+                    stacklevel=2,
+                )
             (_target, _tform) = _rules[0]
 
             _value = self.ruleset.apply_get_transformation(self, _tform, _target, rkg=rkg)

--- a/tests/numerics/test_vode_rules.py
+++ b/tests/numerics/test_vode_rules.py
@@ -311,6 +311,7 @@ def test_a_get_rule_reflects_a_new_value_after_the_cache_is_cleared():
     assert_allclose(vode.get("e"), 2.0 * (H + 1.0))
 
 
+@pytest.mark.filterwarnings("ignore:Multiple output rules matched")
 def test_only_the_first_matching_output_rule_is_applied():
     """`Ruleset` documents that "if multiple output rules match the current status and
     operation, only the first one is executed".
@@ -325,19 +326,15 @@ def test_only_the_first_matching_output_rule_is_applied():
     assert_allclose(vode.get("e"), 2.0 * H)
 
 
-@pytest.mark.bug(
-    "#79: Vode.get print()s 'WARNING: Multiple output rules matched...' to stdout instead of calling warnings.warn "
-    "(the source carries a '# TODO: use warnings')"
-)
 def test_multiple_matching_output_rules_report_through_the_warnings_module():
     """An ambiguous ruleset — two output rules matching one key — has to be reported
     as a real Python warning.
 
     A bare `print` cannot be filtered, captured, routed to a log, or promoted to an
     error with `-W error`, so a CI run cannot fail on it and a notebook user scrolls
-    past it. Worse, the message is emitted while a `jit`ted step is being *traced*:
-    it appears once, at compile time, detached from the step it belongs to, and never
-    again for the thousands of steps that follow.
+    past it. Worse, it would be emitted while a `jit`ted step is being *traced*: it
+    would appear once, at compile time, detached from the step it belongs to, and
+    never again for the thousands of steps that follow.
 
     Meanwhile the effect it warns about is silent data loss — one of the two rules is
     discarded — so this is precisely the situation that warrants a `UserWarning` the


### PR DESCRIPTION
## Bug

`Vode.get` reported an ambiguous ruleset with `print`. The source carried a `# TODO: use warnings`.

## Impact

A bare print cannot be filtered, captured by `pytest.warns`, routed to a log, or promoted to an error with `-W error`, so CI cannot fail on it and a notebook user scrolls past it. Meanwhile the effect it reports, silently discarding every matched rule but the first, is permanent.

## Fix

```python
warnings.warn(
    f"Multiple output rules matched for key '{key}' in status '{self.status}', "
    "only the first is applied.",
    stacklevel=2,
)
```

`UserWarning`, the default, because an ambiguous ruleset is a defect in what the user wrote at authoring time rather than a dubious runtime condition inside the library. It is also the category shown by default in `__main__` and notebooks. The guarding test asserts `pytest.warns(UserWarning, ...)`, and `RuntimeWarning` does not subclass it.

One neighbouring test deliberately builds an ambiguous ruleset to assert the first-rule policy, so it now carries a local `filterwarnings` marker. Verified that it hides nothing: the file passes under `-W error::UserWarning`, and the gate's warning summary still contains only the pre-existing equinox deprecation.

## Known limitation: `stacklevel`

`stacklevel=2` attributes the warning to the caller of `Vode.get`, which is right for a direct `vode.get("e")`. It is wrong for `vode(u, output="e")`, because `Vode.__call__` calls `self.get(...)` internally, so the report lands on `_vode.py:230`. That is the form every tutorial uses.

There is no single correct value: direct `get` wants 2, the `__call__` path wants 3. Left at 2 pending a decision on which entry point to optimise for. Worth knowing that under the default warning filter, dedup is per location, so in the `__call__` case every ambiguous Vode in a model collapses to one report.

Under `jit` the warning fires at trace time only. The `print` it replaces had the same limitation.

Closes #79
