### PR TITLE
Show every layer in a composed transform's repr

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 
 # Notebooks are JSON: keep them LF so nbformat diffs stay readable
 *.ipynb text eol=lf
+
+# Changelog entries are appended concurrently on many branches; take both sides on merge.
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ GitHub release notes.
 
 - `just fix` ran the formatter before the linter, so `ruff check --fix` could leave its rewrites unformatted and `just all` would then fail its own format check.
 - Various lint findings across `pcx`: unsorted imports, deprecated `typing` aliases, implicit `Optional` annotations, stale `# noqa` codes, and an unnecessary `map`/`zip` pairing in `BaseModule.flatten_module_with_keys`.
+- `repr()` of a composed transform names every layer instead of collapsing to the innermost function ([#104](https://github.com/liukidar/pcx/pull/104)).
 
 ## [0.6.2.post3] - 2024-11-03
 

--- a/pcx/functional/_transform.py
+++ b/pcx/functional/_transform.py
@@ -110,10 +110,12 @@ class _BaseTransform(abc.ABC):
         _fns = _make_tuple(fn)
         _fn = _fns[0]
 
+        # The immediate wrapped object, so '__repr__' can name every layer; 'inspect' unwraps the chain regardless.
+        self.__wrapped__ = _fn
+
         # We wrap 'fn' to return the updated values of the parameters as well and to unref the kwargs before passing
         # them to the original function.
         if isinstance(_fn, _BaseTransform):
-            self.__wrapped__ = _fn.__wrapped__
 
             def _map_fn(fn):
                 # 'kwargs' are reffed so we specify is_pytree=True to avoid reffing multiple times them.
@@ -134,7 +136,6 @@ class _BaseTransform(abc.ABC):
                 return _wrap_fn
 
         else:
-            self.__wrapped__ = _fn
 
             def _map_fn(fn):
                 # We unref only when the original function, not a _BaseTransform, is called, as many transformations

--- a/tests/functional/test_transform_internals.py
+++ b/tests/functional/test_transform_internals.py
@@ -99,24 +99,18 @@ def test_repr_of_a_callable_object_names_its_class():
     assert repr(pxf.jit()(_Scaler(2.0))) == "Jit(fn=_Scaler)"
 
 
-@pytest.mark.bug(
-    "#77: _BaseTransform.__init__ collapses __wrapped__ to the innermost function, so repr() of a composed transform "
-    "hides every intermediate layer and the recursive branch in __repr__ is unreachable"
-)
 def test_repr_of_a_nested_transform_names_every_layer():
     """A composed transform must describe the whole stack, not just the innermost
     function.
 
-    `__repr__` contains a branch for exactly this — `repr(self.__wrapped__) if
-    isinstance(self.__wrapped__, _BaseTransform)` — so nested reporting is plainly
-    the intent. But `__init__` sets `self.__wrapped__ = _fn.__wrapped__` when it
-    wraps another transform, which by induction is always the innermost plain
-    function, so that branch can never run.
+    `__repr__` recurses through `self.__wrapped__` while it is a `_BaseTransform`, so
+    every layer names the one below it. That requires `__init__` to keep the immediate
+    wrapped object rather than collapsing it to the innermost plain function.
 
-    The consequence is that `pxf.jit()(f)` and `pxf.jit()(pxf.value_and_grad(m)(f))`
-    print identically while computing entirely different things: one returns a value,
-    the other a `(value, gradients)` pair. Composition is the documented way to build
-    a training step, so this is the object a user most needs to identify.
+    Otherwise `pxf.jit()(f)` and `pxf.jit()(pxf.value_and_grad(m)(f))` would print
+    identically while computing entirely different things: one returns a value, the
+    other a `(value, gradients)` pair. Composition is the documented way to build a
+    training step, so this is the object a user most needs to identify.
     """
     composed = pxf.jit()(pxf.value_and_grad(diff_params())(_affine_loss))
 


### PR DESCRIPTION
## Bug

```python
if isinstance(_fn, _BaseTransform):
    self.__wrapped__ = _fn.__wrapped__     # already the innermost function
else:
    self.__wrapped__ = _fn
```

When wrapping another transform, `__init__` copied that transform's `__wrapped__` rather than storing the transform itself. By induction `__wrapped__` is therefore always the innermost plain function, no matter how deep the stack.

## Impact

`__repr__` has a branch that recurses when `__wrapped__` is itself a transform. It is unreachable, so:

```python
repr(jit(value_and_grad(mask)(f)))   # Jit(fn=f)
repr(jit(f))                         # Jit(fn=f)
```

Identical strings for entirely different computations, which makes `repr` actively misleading when debugging a transform stack.

## Fix

Store the immediate wrapped object. Both branches then assign the same thing, so the assignment moves above the `if`, which is left to distinguish only the `_map_fn` closures. `__repr__` is untouched; it was already correct.

`repr(jit(value_and_grad(mask)(f)))` now gives `Jit(fn=ValueAndGrad(fn=f))`. Single-layer reprs are unchanged.

## Why this is safe

`__wrapped__` is a standard attribute that `inspect.signature` and `inspect.unwrap` follow. `inspect.unwrap` loops until the attribute is absent, so a chain resolves to the same innermost function a collapsed pointer did. Verified at depths 1 to 4, and with `functools.wraps` applied in both directions: signatures are identical to main.

No extra object lifetime either. The inner transform was already reachable from `self.fn` through `_map_fn`'s closure.

Closes #77
