### PR TITLE
Repo hygiene: union-merge CHANGELOG.md, ignore .claude/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 
 # Notebooks are JSON: keep them LF so nbformat diffs stay readable
 *.ipynb text eol=lf
+
+# Changelog entries are appended concurrently on many branches; take both sides on merge.
+CHANGELOG.md merge=union

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,9 @@ docs/source/
 
 # Local scratch space for temporary files (never committed)
 tmp/
+
+# Coding agents
+.aider*
+.claude/
+.codex/
+.cursor/


### PR DESCRIPTION
Two unrelated one-liners, both repo hygiene, both blocking or annoying the open bug-fix PRs.

## CHANGELOG.md merge=union

Thirteen bug-fix branches each append one line to the same `### Fixed` list. Concurrent appends at the same position conflict pairwise: the first merges, every one after it needs manual resolution.

`union` is built into git and takes both sides of a conflicting hunk, which is the right semantics for an append-only list.

**This has to land before the fix PRs.** Git reads `.gitattributes` from the working tree during a merge, so the driver does nothing until the line is already on `main`.

Verified: with the driver present, all nine changelog branches merge into `main` with zero conflicts and the entries land in order. With it removed, the second one conflicts.

## .claude/ in .gitignore

Claude Code puts agent git worktrees under `.claude/worktrees/`. Each is a complete checkout of this repo, inside the repo directory, untracked but not ignored.

`just check` walks into them: the ruff file count goes from 57 to 570 and the run can fail reporting a problem in a copy of the repo rather than the repo. `git add -A` stages them as embedded git repositories. Both happened while working on the fix branches.

Only affects contributors running Claude Code here.