### PR TITLE
Ignore the Claude Code working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ docs/source/
 
 # Local scratch space for temporary files (never committed)
 tmp/
+
+# Claude Code working directory. Holds agent git worktrees, which are full
+# checkouts of this repo and would otherwise be linted and staged as part of it.
+.claude/


### PR DESCRIPTION
## Bug

Claude Code puts agent git worktrees under `.claude/worktrees/`. Each is a complete checkout of this repo, inside the repo directory. The path is untracked but not ignored.

## Impact

`just check` walks into them: the ruff file count goes from 57 to 570, and the run can fail reporting a problem in a *copy* of the repo rather than the repo. `git add -A` stages them as embedded git repositories.

Both happened while working on the bug-fix branches.

## Fix

`.claude/` in `.gitignore`.

## Scope

Only affects contributors running Claude Code in this repo. No effect on anything else.