### PR TITLE
Changelog entries for the bug-fix campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ GitHub release notes.
 - The Docker image and dev container install with `uv` rather than Poetry, and both now build a `just` toolchain.
 - `.readthedocs.yaml` moved from `docs/` to the repository root and installs the `docs` dependency group with `uv`.
 - `docs/source/` is now generated at build time rather than committed. The tutorial notebooks are mirrored in from `examples/` and the API stubs come from `sphinx-apidoc`; `just docs` runs the same steps locally.
+- `CHANGELOG.md` merges with git's `union` driver, and coding agent directories are ignored ([#105](https://github.com/liukidar/pcx/pull/105)).
 
 ### Removed
 
@@ -54,6 +55,18 @@ GitHub release notes.
 - `just fix` ran the formatter before the linter, so `ruff check --fix` could leave its rewrites unformatted and `just all` would then fail its own format check.
 - Various lint findings across `pcx`: unsorted imports, deprecated `typing` aliases, implicit `Optional` annotations, stale `# noqa` codes, and an unnecessary `map`/`zip` pairing in `BaseModule.flatten_module_with_keys`.
 - `repr()` of a composed transform names every layer instead of collapsing to the innermost function ([#104](https://github.com/liukidar/pcx/pull/104)).
+- `Optim.step(scale_by=k)` no longer writes the scaled value back into the caller's gradient tree, so feeding one tree to two optimisers stops compounding the scaling ([#92](https://github.com/liukidar/pcx/pull/92)).
+- `~` in the mask DSL now negates. `_M_not` overrode the tree-application entry point instead of the per-leaf predicate, so `M(A) & ~M(B)` selected the parameters the user asked to exclude ([#93](https://github.com/liukidar/pcx/pull/93)).
+- Vode statuses and rule keys are matched exactly rather than by prefix, so a status named `initialise` no longer fires the `init` ruleset and `set("u", ...)` no longer fires a rule written for `u2` ([#94](https://github.com/liukidar/pcx/pull/94)).
+- `Param` implements the operator and sequence protocols it advertises: `p /= x` and the other augmented assignments mutate in place instead of silently discarding the update, iteration terminates, and `len()`, `float()` and `int()` work ([#95](https://github.com/liukidar/pcx/pull/95)).
+- The global `RKG` key is restored when a transformed function raises, so one failed `pxf.jit` no longer leaves a tracer that breaks every later random draw in the process ([#96](https://github.com/liukidar/pcx/pull/96)).
+- Checkpoints of models using `pxnn.shared` can be loaded again, and `load_params` rejects a shape mismatch instead of overwriting silently ([#97](https://github.com/liukidar/pcx/pull/97)).
+- `EnergyModule.energy()` returns zero for a module with no Vodes instead of raising `TypeError` ([#98](https://github.com/liukidar/pcx/pull/98)).
+- `rkg(n)` returns `n` keys for every `n`, including 1. The no-argument `rkg()` still returns a single bare key ([#99](https://github.com/liukidar/pcx/pull/99)).
+- Modules flatten by sorted attribute name, so two instances of one class no longer get different treedefs because their constructors assigned attributes in different orders ([#100](https://github.com/liukidar/pcx/pull/100)).
+- `pxf.value_and_grad` accepts an integer `argnums` and `pxf.switch` accepts a list of branches, both of which the type annotations already promised ([#101](https://github.com/liukidar/pcx/pull/101)).
+- A mask callable that raises `TypeError` is no longer invoked a second time, so the user sees their own error rather than a chained one pointing at `_process_mask` ([#102](https://github.com/liukidar/pcx/pull/102)).
+- An ambiguous Vode ruleset reports through `warnings.warn` instead of printing to stdout, so it can be filtered, captured or promoted to an error ([#103](https://github.com/liukidar/pcx/pull/103)).
 
 ## [0.6.2.post3] - 2024-11-03
 


### PR DESCRIPTION
## Bug

Two problems with the per-PR approach.

Some fix PRs merged without a changelog entry (#95 among them), so `## [Unreleased]` does not describe what shipped.

And per-PR entries do not work here. Thirteen branches each append one line to the same `### Fixed` list, which conflicts pairwise: after #104 merged, #92 and #98 immediately went red on `CHANGELOG.md`.

## Impact

#105 added `CHANGELOG.md merge=union` to fix exactly this, and it does work with git locally. GitHub's merge button does not apply merge drivers, so it made no difference in practice.

## Fix

One commit with all twelve entries, plus one under Changed for #105 itself. The per-PR entries have been stripped from the open branches, which are all `MERGEABLE` again.

## Merge order

Land this **after** the remaining fix PRs. It names PRs that are still open; if any is dropped, delete its line first.

Covers #92 to #103, and #105. #104's entry is already on main.